### PR TITLE
Add option to omit individual statistics

### DIFF
--- a/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
+++ b/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
@@ -33,6 +33,9 @@ public class StatisticTravelOptions extends TravelOptions {
     @Column(name = "get_closest_sources")
     private boolean getClosestSources = false;
 
+    @Column(name = "omit_individual_statistics")
+    private boolean omitIndividualStatistics = false;
+
     @Transient
     private List<Integer> cellIds = new ArrayList<>();
 
@@ -71,6 +74,7 @@ public class StatisticTravelOptions extends TravelOptions {
         if (useCache != that.useCache) return false;
         if (iFeelLucky != that.iFeelLucky) return false;
         if (getClosestSources != that.getClosestSources) return false;
+        if (omitIndividualStatistics != that.omitIndividualStatistics) return false;
         if (inactiveSources != null ? !inactiveSources.equals(that.inactiveSources) : that.inactiveSources != null)
             return false;
         return cellIds != null ? cellIds.equals(that.cellIds) : that.cellIds == null;
@@ -83,6 +87,7 @@ public class StatisticTravelOptions extends TravelOptions {
         result = 31 * result + (useCache ? 1 : 0);
         result = 31 * result + (iFeelLucky ? 1 : 0);
         result = 31 * result + (getClosestSources ? 1 : 0);
+        result = 31 * result + (omitIndividualStatistics ? 1 : 0);
         result = 31 * result + (cellIds != null ? cellIds.hashCode() : 0);
         return result;
     }
@@ -101,5 +106,13 @@ public class StatisticTravelOptions extends TravelOptions {
 
     public void setCellIds(List<Integer> cellIds) {
         this.cellIds = cellIds;
+    }
+
+    public boolean isOmitIndividualStatistics() {
+        return omitIndividualStatistics;
+    }
+
+    public void setOmitIndividualStatistics(boolean omitIndividualStatistics) {
+        this.omitIndividualStatistics = omitIndividualStatistics;
     }
 }

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -696,7 +696,7 @@ public class TravelOptions implements Serializable {
 		result = 31 * result + (int) (temp ^ (temp >>> 32));
 		temp = Double.doubleToLongBits(walkDownhill);
 		result = 31 * result + (int) (temp ^ (temp >>> 32));
-        result = 31 * result + (rushHour != null ? rushHour.hashCode() : 0);
+		result = 31 * result + (rushHour != null ? rushHour.hashCode() : 0);
 		result = 31 * result + (travelTimes != null ? travelTimes.hashCode() : 0);
 		result = 31 * result + (travelType != null ? travelType.hashCode() : 0);
 		result = 31 * result + (elevationEnabled != null ? elevationEnabled.hashCode() : 0);


### PR DESCRIPTION
If true, individual statistics are not returned in the response. Default is false.