### PR TITLE
Add avoidTransitRouteTypes to transit travel mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: code.route360.net:4567/docker/general-image/service/psql9.6:latest
+image: code.route360.net:4567/docker/general-image/service/psql9.6:0.0.3
 
 cache:
   key: "mvn"

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
                     <includes>
                         <include>**/TestSuite.class</include>
                     </includes>
+                   <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -104,6 +104,9 @@ public class TravelOptions implements Serializable {
     // maximum number of transfers when using public transportation
     @Column(name = "max_transfers") private Integer maxTransfers    = null;
 
+    // Transit route types that should not be used for routing
+    private List<Integer> avoidTransitRouteTypes                    = Collections.emptyList();
+
     @Transient private Double buffer                                = null;
     @Transient private Double simplify                              = null;
     @Transient private PolygonIntersectionMode intersectionMode     = PolygonIntersectionMode.UNION;
@@ -747,7 +750,9 @@ public class TravelOptions implements Serializable {
                 Objects.equals(travelTypes, that.travelTypes) &&
                 Objects.equals(osmTypes, that.osmTypes) &&
                 Objects.equals(customPois, that.customPois) &&
-                Objects.equals(travelTimeFactors, that.travelTimeFactors);
+                Objects.equals(travelTimeFactors, that.travelTimeFactors) &&
+                Objects.equals(maxTransfers, that.maxTransfers) &&
+                Objects.equals(avoidTransitRouteTypes, that.avoidTransitRouteTypes);
     }
                 
 
@@ -771,7 +776,7 @@ public class TravelOptions implements Serializable {
                 maxEdgeWeight, serviceUrl, fallbackServiceUrl, serviceKey, onlyPrintReachablePoints, edgeWeightType,
                 statisticIds, statisticGroupId, statisticServiceUrl, pointOfInterestServiceUrl, overpassQuery,
                 overpassServiceUrl, interServiceKey, format, boundingBox, travelTypes, osmTypes, customPois,
-                travelTimeFactors);
+                travelTimeFactors, maxTransfers, avoidTransitRouteTypes);
     }
 
     /* (non-Javadoc)
@@ -917,6 +922,10 @@ public class TravelOptions implements Serializable {
         builder.append(customPois != null ? toString(customPois, maxLen) : null);
         builder.append("\n\ttravelTimeFactors: ");
         builder.append(travelTimeFactors != null ? toString(travelTimeFactors.entrySet(), maxLen) : null);
+        builder.append("\n\tmaxTransfers: ");
+        builder.append(maxTransfers);
+        builder.append("\n\tavoidTransitRouteTypes: ");
+        builder.append(avoidTransitRouteTypes != null ? toString(avoidTransitRouteTypes, maxLen) : null);
         builder.append("\n}\n");
         return builder.toString();
     }
@@ -1319,5 +1328,13 @@ public class TravelOptions implements Serializable {
 
     public void setDisableCache(boolean disableCache) {
         this.disableCache = disableCache;
+    }
+
+    public List<Integer> getAvoidTransitRouteTypes() {
+        return avoidTransitRouteTypes;
+    }
+
+    public void setAvoidTransitRouteTypes(List<Integer> avoidTransitRouteTypes) {
+        this.avoidTransitRouteTypes = avoidTransitRouteTypes;
     }
 }

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -335,6 +335,9 @@ public final class RequestConfigurator {
                 if (travelOptions.getMaxWalkingTimeToTarget() != null && travelOptions.getMaxWalkingTimeToTarget() >= 0) {
                     travelMode.put("maxWalkingTimeToTarget", travelOptions.getMaxWalkingTimeToTarget());
                 }
+                if (travelOptions.getAvoidTransitRouteTypes() != null && !travelOptions.getAvoidTransitRouteTypes().isEmpty()) {
+                    travelMode.put("avoidTransitRouteTypes", travelOptions.getAvoidTransitRouteTypes());
+                }
                 travelMode.put(Constants.TRANSPORT_MODE_TRANSIT_RECOMMENDATIONS, travelOptions.getRecommendations());
                 travelMode.put(Constants.TRAVEL_MODE_SPEED, travelOptions.getWalkSpeed());
                 travelMode.put(Constants.TRAVEL_MODE_UPHILL, travelOptions.getWalkUphill());


### PR DESCRIPTION
Adds `avoidTransitRouteTypes` (int list) to TravelOptions to disable certain route types for routing.

Route types can be found here: https://developers.google.com/transit/gtfs/reference/#routestxt and here: https://developers.google.com/transit/gtfs/reference/extended-route-types

Also adds `maxTransfers` to object comparision and hash etc, where it was missing.