### PR TITLE
Fix for traffic penalty comparison in `TravelOptions.equals()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To perform a release simply do: `mvn clean deploy -DperformRelease=true`
 
 ## Release Notes
 
+### 0.1.5.1
+- fixed traffic penalty comparison in `TravelOptions.equals()`
+
 ### 0.1.5
 - added parameter "avoidTransitRouteTypes"
 - added parameters for multigraph aggregation pipeline

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.targomo</groupId>
     <artifactId>java-client</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.5.1</version>
     <name>Targomo Java Client Library</name>
     <description>Java client library for easy usage of Targomo web services.</description>
     <url>https://github.com/targomo/targomo-java</url>

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -737,8 +737,8 @@ public class TravelOptions implements Serializable {
                 Double.compare(that.walkSpeed, walkSpeed) == 0 &&
                 Double.compare(that.walkUphill, walkUphill) == 0 &&
                 Double.compare(that.walkDownhill, walkDownhill) == 0 &&
-                Integer.compare(that.trafficJunctionPenalty, trafficJunctionPenalty) == 0 &&
-                Integer.compare(that.trafficSignalPenalty, trafficSignalPenalty) == 0 &&
+                Objects.equals(that.trafficJunctionPenalty, trafficJunctionPenalty) &&
+                Objects.equals(that.trafficSignalPenalty, trafficSignalPenalty) &&
                 onlyPrintReachablePoints == that.onlyPrintReachablePoints &&
                 Objects.equals(sources, that.sources) &&
                 Objects.equals(targets, that.targets) &&


### PR DESCRIPTION
`trafficSignalPenalty` and `trafficJunctionPenalty` compared using Objects.equals() to prevent null pointer exception