### PR TITLE
Force Right Hand Orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ nexus and to the maven repo (last is only possibly from master).
 ### 0.1.11
 - new aggregation type "count" for multigraph 
 - Update to prepare for use of geometries (LineStrings, Polygons and MultiPolygons) as sources.
-- added `polygonOrientation` parameter to polygon requests
+- added `polygonOrientationRule` parameter to polygon requests
 
 ### 0.1.10 skipped
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ nexus and to the maven repo (last is only possibly from master).
 ### 0.1.11
 - new aggregation type "count" for multigraph 
 - Update to prepare for use of geometries (LineStrings, Polygons and MultiPolygons) as sources.
-- added `forceRightHandOrientation` parameter to polygon requests
+- added `polygonOrientation` parameter to polygon requests
 
 ### 0.1.10 skipped
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ nexus and to the maven repo (last is only possibly from master).
 
 ### 0.1.11
 - new aggregation type "count" for multigraph 
+- added `forceRightHandOrientation` parameter to polygon requests
 
 ### 0.1.10 skipped
 

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -55,7 +55,7 @@ public class Constants {
     public static final String X                                                        = "x";
     public static final String CALLBACK                                                 = "callback";
     public static final String SRID                                                     = "srid";
-    public static final String POLYGON_ORIENTATION                                      = "polygonOrientation";
+    public static final String POLYGON_ORIENTATION_RULE                                 = "polygonOrientationRule";
     public static final String DECIMAL_PRECISION                                        = "decimalPrecision";
     public static final String DISABLE_CACHE                                            = "disableCache";
 

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -54,6 +54,7 @@ public class Constants {
     public static final String X                                                        = "x";
     public static final String CALLBACK                                                 = "callback";
     public static final String SRID                                                     = "srid";
+    public static final String FORCE_RIGHT_HAND_ORIENTATION                             = "forceRightHandOrientation";
     public static final String DECIMAL_PRECISION                                        = "decimalPrecision";
     public static final String DISABLE_CACHE                                            = "disableCache";
 

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -55,7 +55,7 @@ public class Constants {
     public static final String X                                                        = "x";
     public static final String CALLBACK                                                 = "callback";
     public static final String SRID                                                     = "srid";
-    public static final String FORCE_RIGHT_HAND_ORIENTATION                             = "forceRightHandOrientation";
+    public static final String POLYGON_ORIENTATION                                      = "polygonOrientation";
     public static final String DECIMAL_PRECISION                                        = "decimalPrecision";
     public static final String DISABLE_CACHE                                            = "disableCache";
 

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -104,6 +104,7 @@ public class TravelOptions implements Serializable {
     @Transient private Integer maxWalkingTimeToTarget               = null;
     @Transient private Integer recommendations                      = 0;
     @Transient private Integer srid                                 = null;
+    @Transient private Boolean forceRightHandOrientation            = null;
     @Transient private Integer decimalPrecision                     = null;
 
     // maximum number of transfers when using public transportation
@@ -785,6 +786,7 @@ public class TravelOptions implements Serializable {
 				Objects.equals(intersectionGeometry, that.intersectionGeometry) &&
                 Objects.equals(recommendations, that.recommendations) &&
                 Objects.equals(srid, that.srid) &&
+                Objects.equals(forceRightHandOrientation, that.forceRightHandOrientation) &&
                 Objects.equals(decimalPrecision, that.decimalPrecision) &&
                 Objects.equals(buffer, that.buffer) &&
                 Objects.equals(simplify, that.simplify) &&
@@ -851,7 +853,7 @@ public class TravelOptions implements Serializable {
 
         return Objects.hash(sources, targets, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
                 rushHour, travelTimes, travelType, elevationEnabled, appendTravelTimes, pointReduction, reverse,
-                minPolygonHoleSize, time, date, frame, recommendations, srid, decimalPrecision, buffer, simplify,
+                minPolygonHoleSize, time, date, frame, recommendations, srid, forceRightHandOrientation, decimalPrecision, buffer, simplify,
                 intersectionMode, pathSerializer, polygonSerializerType, intersectionGeometry,
                 multiGraphEdgeClasses, multiGraphSerializationFormat,
                 multiGraphSerializationDecimalPrecision, multiGraphSerializationMaxGeometryCount,
@@ -927,6 +929,8 @@ public class TravelOptions implements Serializable {
         builder.append(recommendations);
         builder.append("\n\tsrid: ");
         builder.append(srid);
+        builder.append("\n\tforceRightHandOrientation: ");
+        builder.append(forceRightHandOrientation);
         builder.append("\n\tdecimalPrecision: ");
         builder.append(decimalPrecision);
         builder.append("\n\tbuffer: ");
@@ -1143,6 +1147,14 @@ public class TravelOptions implements Serializable {
 
     public void setSrid(Integer srid) {
         this.srid = srid;
+    }
+
+    public Boolean getForceRightHandOrientation() {
+        return forceRightHandOrientation;
+    }
+
+    public void setForceRightHandOrientation(Boolean forceRightHandOrientation) {
+        this.forceRightHandOrientation = forceRightHandOrientation;
     }
 
     public Integer getDecimalPrecision() {

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -104,7 +104,7 @@ public class TravelOptions implements Serializable {
     @Transient private Integer maxWalkingTimeToTarget               = null;
     @Transient private Integer recommendations                      = 0;
     @Transient private Integer srid                                 = null;
-    @Transient private Boolean forceRightHandOrientation            = null;
+    @Transient private PolygonOrientation polygonOrientation        = null;
     @Transient private Integer decimalPrecision                     = null;
 
     // maximum number of transfers when using public transportation
@@ -809,7 +809,7 @@ public class TravelOptions implements Serializable {
 				Objects.equals(intersectionGeometry, that.intersectionGeometry) &&
                 Objects.equals(recommendations, that.recommendations) &&
                 Objects.equals(srid, that.srid) &&
-                Objects.equals(forceRightHandOrientation, that.forceRightHandOrientation) &&
+                Objects.equals(polygonOrientation, that.polygonOrientation) &&
                 Objects.equals(decimalPrecision, that.decimalPrecision) &&
                 Objects.equals(buffer, that.buffer) &&
                 Objects.equals(simplify, that.simplify) &&
@@ -876,7 +876,7 @@ public class TravelOptions implements Serializable {
 
         return Objects.hash(sources, sourceGeometries, targets, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
                 rushHour, travelTimes, travelType, elevationEnabled, appendTravelTimes, pointReduction, reverse,
-                minPolygonHoleSize, time, date, frame, recommendations, srid, forceRightHandOrientation, decimalPrecision, buffer, simplify,
+                minPolygonHoleSize, time, date, frame, recommendations, srid, polygonOrientation, decimalPrecision, buffer, simplify,
                 intersectionMode, pathSerializer, polygonSerializerType, intersectionGeometry,
                 multiGraphEdgeClasses, multiGraphSerializationFormat,
                 multiGraphSerializationDecimalPrecision, multiGraphSerializationMaxGeometryCount,
@@ -954,8 +954,8 @@ public class TravelOptions implements Serializable {
         builder.append(recommendations);
         builder.append("\n\tsrid: ");
         builder.append(srid);
-        builder.append("\n\tforceRightHandOrientation: ");
-        builder.append(forceRightHandOrientation);
+        builder.append("\n\tpolygonOrientation: ");
+        builder.append(polygonOrientation);
         builder.append("\n\tdecimalPrecision: ");
         builder.append(decimalPrecision);
         builder.append("\n\tbuffer: ");
@@ -1183,12 +1183,12 @@ public class TravelOptions implements Serializable {
         this.srid = srid;
     }
 
-    public Boolean getForceRightHandOrientation() {
-        return forceRightHandOrientation;
+    public PolygonOrientation getPolygonOrientation() {
+        return polygonOrientation;
     }
 
-    public void setForceRightHandOrientation(Boolean forceRightHandOrientation) {
-        this.forceRightHandOrientation = forceRightHandOrientation;
+    public void setPolygonOrientation(PolygonOrientation polygonOrientation) {
+        this.polygonOrientation = polygonOrientation;
     }
 
     public Integer getDecimalPrecision() {

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -104,7 +104,7 @@ public class TravelOptions implements Serializable {
     @Transient private Integer maxWalkingTimeToTarget               = null;
     @Transient private Integer recommendations                      = 0;
     @Transient private Integer srid                                 = null;
-    @Transient private PolygonOrientation polygonOrientation        = null;
+    @Transient private PolygonOrientationRule polygonOrientationRule = null;
     @Transient private Integer decimalPrecision                     = null;
 
     // maximum number of transfers when using public transportation
@@ -809,7 +809,7 @@ public class TravelOptions implements Serializable {
 				Objects.equals(intersectionGeometry, that.intersectionGeometry) &&
                 Objects.equals(recommendations, that.recommendations) &&
                 Objects.equals(srid, that.srid) &&
-                Objects.equals(polygonOrientation, that.polygonOrientation) &&
+                Objects.equals(polygonOrientationRule, that.polygonOrientationRule) &&
                 Objects.equals(decimalPrecision, that.decimalPrecision) &&
                 Objects.equals(buffer, that.buffer) &&
                 Objects.equals(simplify, that.simplify) &&
@@ -876,7 +876,7 @@ public class TravelOptions implements Serializable {
 
         return Objects.hash(sources, sourceGeometries, targets, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
                 rushHour, travelTimes, travelType, elevationEnabled, appendTravelTimes, pointReduction, reverse,
-                minPolygonHoleSize, time, date, frame, recommendations, srid, polygonOrientation, decimalPrecision, buffer, simplify,
+                minPolygonHoleSize, time, date, frame, recommendations, srid, polygonOrientationRule, decimalPrecision, buffer, simplify,
                 intersectionMode, pathSerializer, polygonSerializerType, intersectionGeometry,
                 multiGraphEdgeClasses, multiGraphSerializationFormat,
                 multiGraphSerializationDecimalPrecision, multiGraphSerializationMaxGeometryCount,
@@ -954,8 +954,8 @@ public class TravelOptions implements Serializable {
         builder.append(recommendations);
         builder.append("\n\tsrid: ");
         builder.append(srid);
-        builder.append("\n\tpolygonOrientation: ");
-        builder.append(polygonOrientation);
+        builder.append("\n\tpolygonOrientationRule: ");
+        builder.append(polygonOrientationRule);
         builder.append("\n\tdecimalPrecision: ");
         builder.append(decimalPrecision);
         builder.append("\n\tbuffer: ");
@@ -1183,12 +1183,12 @@ public class TravelOptions implements Serializable {
         this.srid = srid;
     }
 
-    public PolygonOrientation getPolygonOrientation() {
-        return polygonOrientation;
+    public PolygonOrientationRule getPolygonOrientationRule() {
+        return polygonOrientationRule;
     }
 
-    public void setPolygonOrientation(PolygonOrientation polygonOrientation) {
-        this.polygonOrientation = polygonOrientation;
+    public void setPolygonOrientationRule(PolygonOrientationRule polygonOrientationRule) {
+        this.polygonOrientationRule = polygonOrientationRule;
     }
 
     public Integer getDecimalPrecision() {

--- a/src/main/java/com/targomo/client/api/enums/PolygonOrientation.java
+++ b/src/main/java/com/targomo/client/api/enums/PolygonOrientation.java
@@ -1,0 +1,30 @@
+package com.targomo.client.api.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.stream.Stream;
+
+public enum PolygonOrientation {
+    RIGHT_HAND("right_hand"),
+    LEFT_HAND("left_hand");
+
+    private String key;
+
+    PolygonOrientation(String key) {
+        this.key = key;
+    }
+
+    @JsonCreator
+    public static PolygonOrientation fromString(String key) {
+        return key == null ? null : Stream.of(PolygonOrientation.values())
+                .filter( enu -> enu.key.equalsIgnoreCase(key)).findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid " +
+                        Format.class.getSimpleName() + " specified: " + key + " doesn't exist"));
+    }
+
+    @JsonValue
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/targomo/client/api/enums/PolygonOrientationRule.java
+++ b/src/main/java/com/targomo/client/api/enums/PolygonOrientationRule.java
@@ -5,19 +5,19 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.stream.Stream;
 
-public enum PolygonOrientation {
+public enum PolygonOrientationRule {
     RIGHT_HAND("right_hand"),
     LEFT_HAND("left_hand");
 
     private String key;
 
-    PolygonOrientation(String key) {
+    PolygonOrientationRule(String key) {
         this.key = key;
     }
 
     @JsonCreator
-    public static PolygonOrientation fromString(String key) {
-        return key == null ? null : Stream.of(PolygonOrientation.values())
+    public static PolygonOrientationRule fromString(String key) {
+        return key == null ? null : Stream.of(PolygonOrientationRule.values())
                 .filter( enu -> enu.key.equalsIgnoreCase(key)).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid " +
                         Format.class.getSimpleName() + " specified: " + key + " doesn't exist"));

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -170,6 +170,9 @@ public final class RequestConfigurator {
 		if ( travelOptions.getSrid() != null )
 			polygon.put(Constants.SRID, travelOptions.getSrid());
 
+        if ( travelOptions.getForceRightHandOrientation() != null )
+            polygon.put(Constants.FORCE_RIGHT_HAND_ORIENTATION, travelOptions.getForceRightHandOrientation());
+
         if ( travelOptions.getDecimalPrecision() != null )
             polygon.put(Constants.DECIMAL_PRECISION, travelOptions.getDecimalPrecision());
 		

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -175,8 +175,8 @@ public final class RequestConfigurator {
 		if ( travelOptions.getSrid() != null )
 			polygon.put(Constants.SRID, travelOptions.getSrid());
 
-        if ( travelOptions.getForceRightHandOrientation() != null )
-            polygon.put(Constants.FORCE_RIGHT_HAND_ORIENTATION, travelOptions.getForceRightHandOrientation());
+        if ( travelOptions.getPolygonOrientation() != null )
+            polygon.put(Constants.POLYGON_ORIENTATION, travelOptions.getPolygonOrientation());
 
         if ( travelOptions.getDecimalPrecision() != null )
             polygon.put(Constants.DECIMAL_PRECISION, travelOptions.getDecimalPrecision());

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -175,8 +175,8 @@ public final class RequestConfigurator {
 		if ( travelOptions.getSrid() != null )
 			polygon.put(Constants.SRID, travelOptions.getSrid());
 
-        if ( travelOptions.getPolygonOrientation() != null )
-            polygon.put(Constants.POLYGON_ORIENTATION, travelOptions.getPolygonOrientation());
+        if ( travelOptions.getPolygonOrientationRule() != null )
+            polygon.put(Constants.POLYGON_ORIENTATION_RULE, travelOptions.getPolygonOrientationRule());
 
         if ( travelOptions.getDecimalPrecision() != null )
             polygon.put(Constants.DECIMAL_PRECISION, travelOptions.getDecimalPrecision());

--- a/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
+++ b/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
@@ -156,6 +156,7 @@ public class RequestConfiguratorTest {
             options.setDate(20161020);
             options.setTime(55852);
             options.setSrid(25833);
+            options.setPolygonOrientationRule(PolygonOrientationRule.RIGHT_HAND);
 	        options.setEdgeWeightType(EdgeWeightType.DISTANCE);
             options.setMaxTransfers(2);
             options.getTravelTimeFactors().put("all",0.9);
@@ -288,5 +289,8 @@ public class RequestConfiguratorTest {
 		
 		Assert.assertEquals(samplePolygon.get(Constants.SRID),
 				actualPolygon.get(Constants.SRID));
+
+        Assert.assertEquals(samplePolygon.getString(Constants.POLYGON_ORIENTATION_RULE).toLowerCase(),
+                actualPolygon.getString(Constants.POLYGON_ORIENTATION_RULE).toLowerCase());
 	}
 }

--- a/src/test/resources/data/PolygonRequestCfgSample.json
+++ b/src/test/resources/data/PolygonRequestCfgSample.json
@@ -13,6 +13,7 @@
     ],
     "minPolygonHoleSize": 100000000,
     "serializer": "json",
+    "polygonOrientationRule" : "right_hand",
     "srid" : 25833
   },
   "sources": [


### PR DESCRIPTION
Add `forceRightHandOrientation` request as optional boolean parameter to polygon requests. If true will force returned polygons to follow the right hand rule

```json
...
"polygon" : {
  ...
  "forceRightHandOrientation" : true,
  ...
},
...
```