### PR TITLE
Bump log4j-core from 2.13.2 to 2.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ nexus and to the maven repo (last is only possibly from master).
 
 ## Release Notes
 
+### 0.9.0
+- Upgrade log4j-core to 2.15.0
+
 ### 0.8.0
 - Add `maxSnapDistance` parameter in the TravelOptions
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.2</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bumps log4j-core from 2.13.2 to 2.15.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>