### PR TITLE
Refactor EdgeStatisticsRequest, add possibility to request multiple statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ nexus and to the maven repo (last is only possibly from master).
 
 ## Release Notes
 
+### 0.22.0
+- Refactor EdgeStatisticsRequest, add possibility to request multiple statistics
+
 ### 0.21.0
 - Adding new Aggregation types `mean` `sum` in CompetingRouting
 - Update versions for java 17

--- a/src/main/java/com/targomo/client/api/pojo/EdgeStatisticsRequestOptions.java
+++ b/src/main/java/com/targomo/client/api/pojo/EdgeStatisticsRequestOptions.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Parameters for an edge statistics request.
+ * Parameters for an edge statistics location request.
  */
 @Getter @Setter
 @AllArgsConstructor @NoArgsConstructor

--- a/src/main/java/com/targomo/client/api/pojo/EdgeStatisticsRequestOptions.java
+++ b/src/main/java/com/targomo/client/api/pojo/EdgeStatisticsRequestOptions.java
@@ -1,26 +1,31 @@
 package com.targomo.client.api.pojo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.targomo.client.api.enums.EdgeStatisticDirection;
 import com.targomo.client.api.enums.TravelType;
+import com.targomo.client.api.geo.DefaultTargetCoordinate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Parameters for an edge statistics request.
  */
-@Getter @AllArgsConstructor
+@Getter @Setter
+@AllArgsConstructor @NoArgsConstructor
 public class EdgeStatisticsRequestOptions {
 
-    private final String serviceUrl;
-    private final String serviceKey;
+    private List<Integer> edgeStatisticIds = new ArrayList<>();
 
-    private final Integer edgeStatisticGroupId;
-    private final Integer edgeStatisticId;
+    private Integer radius = 100;
+    private TravelType travelType = TravelType.CAR;
+    private EdgeStatisticDirection direction = EdgeStatisticDirection.ANY;
+    private List<Integer> ignoreRoadClasses = new ArrayList<>();
 
-    private final Integer radius;
-    private final TravelType travelType;
-    private final EdgeStatisticDirection direction;
-    private final List<Integer> ignoreRoadClasses;
+    @JsonIgnoreProperties({"travelType", "properties"})
+    private List<DefaultTargetCoordinate> locations = new ArrayList<>();
 }

--- a/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
+++ b/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
@@ -36,8 +36,7 @@ public class EdgeStatisticsRequest {
 
 	/**
 	 * Use a custom client implementation with specified options and method
-	 * @param client Client implementation to be used
-	 * @param requestOptions Options to be used
+	 * @see EdgeStatisticsRequest#EdgeStatisticsRequest(Client, String, String, int, EdgeStatisticsRequestOptions, MultivaluedMap)
 	 */
 	public EdgeStatisticsRequest(Client client, String serviceUrl, String serviceKey, int edgeStatisticCollectionId,
 								 EdgeStatisticsRequestOptions requestOptions) {
@@ -47,7 +46,7 @@ public class EdgeStatisticsRequest {
 	/**
 	 * Use default client implementation with specified options and method
 	 * Default client uses {@link ClientBuilder}
-	 * @param requestOptions Options to be used
+	 * @see EdgeStatisticsRequest#EdgeStatisticsRequest(Client, String, String, int, EdgeStatisticsRequestOptions, MultivaluedMap)
 	 */
 	public EdgeStatisticsRequest(String serviceUrl, String serviceKey, int edgeStatisticCollectionId,
 								 EdgeStatisticsRequestOptions requestOptions) {
@@ -57,6 +56,9 @@ public class EdgeStatisticsRequest {
 	/**
 	 * Use a custom client implementation with specified options, method, and headers
 	 * @param client Client implementation to be used
+	 * @param serviceUrl The url for the service
+	 * @param serviceKey The api key
+	 * @param edgeStatisticCollectionId Id of the statistic collection
 	 * @param requestOptions Options to be used
 	 * @param headers List of custom http headers to be used
 	 */
@@ -71,7 +73,7 @@ public class EdgeStatisticsRequest {
 	}
 
 	/**
-	 * @return map of location id to edge statistics value
+	 * @return map of location id to a map of edge statistic id to statistic value
 	 * @throws JSONException In case the returned response is not parsable
 	 * @throws TargomoClientException In case of other errors
 	 */

--- a/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
+++ b/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
@@ -3,16 +3,12 @@ package com.targomo.client.api.request;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.targomo.client.Constants;
 import com.targomo.client.api.exception.TargomoClientException;
 import com.targomo.client.api.exception.TargomoClientRuntimeException;
-import com.targomo.client.api.geo.Coordinate;
 import com.targomo.client.api.pojo.EdgeStatisticsRequestOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -23,7 +19,6 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,18 +26,22 @@ import java.util.Map;
 public class EdgeStatisticsRequest {
 
 	private final Client client;
-	private final EdgeStatisticsRequestOptions requestOptions;
 	private final MultivaluedMap<String, Object> headers;
+
+	String serviceUrl;
+	String serviceKey;
+
+	int edgeStatisticCollectionId;
+	private final EdgeStatisticsRequestOptions requestOptions;
 
 	/**
 	 * Use a custom client implementation with specified options and method
 	 * @param client Client implementation to be used
 	 * @param requestOptions Options to be used
 	 */
-	public EdgeStatisticsRequest(Client client, EdgeStatisticsRequestOptions requestOptions) {
-		this.client	= client;
-		this.requestOptions = requestOptions;
-		this.headers = new MultivaluedHashMap<>();
+	public EdgeStatisticsRequest(Client client, String serviceUrl, String serviceKey, int edgeStatisticCollectionId,
+								 EdgeStatisticsRequestOptions requestOptions) {
+		this(client, serviceUrl, serviceKey, edgeStatisticCollectionId, requestOptions, new MultivaluedHashMap<>());
 	}
 
 	/**
@@ -50,8 +49,9 @@ public class EdgeStatisticsRequest {
 	 * Default client uses {@link ClientBuilder}
 	 * @param requestOptions Options to be used
 	 */
-	public EdgeStatisticsRequest(EdgeStatisticsRequestOptions requestOptions) {
-		this(ClientBuilder.newClient(), requestOptions);
+	public EdgeStatisticsRequest(String serviceUrl, String serviceKey, int edgeStatisticCollectionId,
+								 EdgeStatisticsRequestOptions requestOptions) {
+		this(ClientBuilder.newClient(), serviceUrl, serviceKey, edgeStatisticCollectionId, requestOptions);
 	}
 
 	/**
@@ -60,44 +60,32 @@ public class EdgeStatisticsRequest {
 	 * @param requestOptions Options to be used
 	 * @param headers List of custom http headers to be used
 	 */
-	public EdgeStatisticsRequest(Client client, EdgeStatisticsRequestOptions requestOptions, MultivaluedMap<String, Object> headers) {
+	public EdgeStatisticsRequest(Client client, String serviceUrl, String serviceKey, int edgeStatisticCollectionId,
+								 EdgeStatisticsRequestOptions requestOptions, MultivaluedMap<String, Object> headers) {
 		this.client	= client;
 		this.requestOptions = requestOptions;
 		this.headers = headers;
+		this.serviceUrl = serviceUrl;
+		this.serviceKey = serviceKey;
+		this.edgeStatisticCollectionId = edgeStatisticCollectionId;
 	}
 
 	/**
-	 * @param locations Coordinate collection of locations
 	 * @return map of location id to edge statistics value
 	 * @throws JSONException In case the returned response is not parsable
 	 * @throws TargomoClientException In case of other errors
 	 */
-	public Map<String, Double> get(Collection<Coordinate> locations) throws TargomoClientException, JSONException {
+	public Map<String, Map<Integer, Double>> get() throws TargomoClientException, JsonProcessingException {
 
-		String path = buildLocationsPath(requestOptions.getEdgeStatisticGroupId(), requestOptions.getEdgeStatisticId());
-		WebTarget target = client.target(requestOptions.getServiceUrl()).path(path)
-				.queryParam("key", requestOptions.getServiceKey())
-				.queryParam("radius", requestOptions.getRadius())
-				.queryParam("travelType", requestOptions.getTravelType())
-				.queryParam("direction", requestOptions.getDirection());
-
-		if (requestOptions.getIgnoreRoadClasses() != null) {
-			for (Integer clazz : requestOptions.getIgnoreRoadClasses()) {
-				target = target.queryParam("ignoreRoadClass", clazz);
-			}
-		}
-
-		final Entity<String> entity = Entity.entity(parseLocations(locations), MediaType.APPLICATION_JSON_TYPE);
+		String path = StringUtils.join(Arrays.asList(String.valueOf(this.edgeStatisticCollectionId), "locations"), "/");
+		WebTarget target = client.target(serviceUrl).path(path).queryParam("key", serviceKey);
 
 		log.debug(String.format("Executing edge statistics request (%s) to URI: '%s'", path, target.getUri()));
 
 		// Execute POST request
+		final Entity<String> entity = Entity.entity(new ObjectMapper().writeValueAsString(requestOptions), MediaType.APPLICATION_JSON_TYPE);
 		Response response = target.request().headers(headers).post(entity);
 		return parseResponse(response);
-	}
-
-	private static String buildLocationsPath(Integer edgeStatisticGroupId, Integer edgeStatisticId) {
-		return StringUtils.join(Arrays.asList("locations", String.valueOf(edgeStatisticGroupId), String.valueOf(edgeStatisticId)), "/");
 	}
 
 	/**
@@ -106,41 +94,25 @@ public class EdgeStatisticsRequest {
 	 * @return map of location id to edge statistics value
 	 * @throws TargomoClientException In case of errors
 	 */
-	private Map<String, Double> parseResponse(final Response response)
+	private Map<String, Map<Integer, Double>> parseResponse(final Response response)
 			throws TargomoClientException {
 
-		// compare the HTTP status codes, NOT the route 360 code
+		String responseStr = response.readEntity(String.class);
+
+		// compare the HTTP status codes, NOT the Targomo code
 		if (response.getStatus() == Response.Status.OK.getStatusCode()) {
 
 			// consume the results
 			try {
-				TypeReference<HashMap<String, Double>> typeRef = new TypeReference<HashMap<String, Double>>() {};
-				return new ObjectMapper().readValue(response.readEntity(String.class), typeRef);
+				TypeReference<HashMap<String, Map<Integer, Double>>> typeRef = new TypeReference<HashMap<String, Map<Integer, Double>>>() {};
+				return new ObjectMapper().readValue(responseStr, typeRef);
 			}
 			catch (JsonProcessingException e){
 				throw new TargomoClientRuntimeException("Couldn't parse Edge Statistics response", e);
 			}
 		}
 		else {
-			throw new TargomoClientException(response.readEntity(String.class), response.getStatus());
+			throw new TargomoClientException(responseStr, response.getStatus());
 		}
-	}
-
-	/**
-	 * @param locations Coordinate collection of locations to be parsed
-	 * @return Locations parsed into JSON
-	 * @throws JSONException In case something cannot be parsed
-	 */
-	private static String parseLocations(Collection<Coordinate> locations) throws JSONException {
-
-		JSONArray locationsJson = new JSONArray();
-		for (Coordinate l : locations) {
-			locationsJson.put(new JSONObject()
-				.put(Constants.ID, l.getId())
-				.put(Constants.Y, l.getY())
-				.put(Constants.X, l.getX())
-			);
-		}
-		return locationsJson.toString();
 	}
 }


### PR DESCRIPTION
Sends most the request parameters in the request body now (EdgeStatisticsRequestOptions). Only collection id is still part of path (required for dispatching on the proxy).