### PR TITLE
Feature/gc h3 trg src

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ nexus and to the maven repo (last is only possibly from master).
 - Remove use of the temporary parameter "multiple" for poi gravitation
 - Add `allowPrivateAndServiceRoads` parameter
 - Add `arrivalOrDepartureDuration` parameter
+- Add option for `sourceAddresses` and `targetAddresses` using H3 Addresses
 
 ### 0.31.0
 - Allow edgeStatisticsServiceUrl and mobilityServiceUrl to be null

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
     public static final String H3_ADDRESS                                               = "h3Address";
     public static final String TARGETS                                                  = "targets";
     public static final String TARGET_GEOHASHES                                         = "targetGeohashes";
+    public static final String TARGET_ADDRESSES                                         = "targetAddresses";
     public static final String ENABLE_ELEVATION                                         = "elevation";
     public static final String JSON_POLYGON_SERIALIZER                                  = "json";
     public static final String GEO_JSON_POLYGON_SERIALIZER                              = "geojson";

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -24,6 +24,8 @@ public class Constants {
     public static final String PROPERTIES                                               = "properties";
     public static final String SOURCES                                                  = "sources";
     public static final String SOURCE_GEOMETRIES                                        = "sourceGeometries";
+    public static final String SOURCE_ADDRESSES                                         = "sourceAddresses";
+    public static final String H3_ADDRESS                                               = "h3Address";
     public static final String TARGETS                                                  = "targets";
     public static final String TARGET_GEOHASHES                                         = "targetGeohashes";
     public static final String ENABLE_ELEVATION                                         = "elevation";

--- a/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
+++ b/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
@@ -5,14 +5,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.targomo.client.api.enums.MultiGraphTravelTimeApproximation;
 import com.targomo.client.api.enums.RoutingAggregationType;
-import com.targomo.client.api.geo.AbstractGeometry;
-import com.targomo.client.api.geo.Coordinate;
-import com.targomo.client.api.geo.DefaultSourceCoordinate;
-import com.targomo.client.api.geo.DefaultSourceGeometry;
-import com.targomo.client.api.json.DefaultSourceCoordinateMapDeserializer;
-import com.targomo.client.api.json.DefaultSourceCoordinateMapSerializer;
-import com.targomo.client.api.json.DefaultSourceGeometriesMapDeserializer;
-import com.targomo.client.api.json.DefaultSourceGeometriesMapSerializer;
+import com.targomo.client.api.geo.*;
+import com.targomo.client.api.json.*;
 import com.targomo.client.api.pojo.CompetingRoutingOption;
 import lombok.Data;
 
@@ -34,6 +28,11 @@ public class StatisticTravelOptions extends TravelOptions {
     @JsonSerialize(contentAs=DefaultSourceCoordinate.class, using=DefaultSourceCoordinateMapSerializer.class)
     @Transient
     private Map<String,Coordinate> inactiveSources = new HashMap<>();
+
+    @JsonDeserialize(contentAs= DefaultSourceAddress.class, using= DefaultSourceAddressMapDeserializer.class)
+    @JsonSerialize(contentAs=DefaultSourceAddress.class, using=DefaultSourceAddressMapSerializer.class)
+    @Transient
+    private Map<String,DefaultSourceAddress> inactiveSourceAddresses = new HashMap<>();
 
     @JsonDeserialize(contentAs= DefaultSourceGeometry.class, using= DefaultSourceGeometriesMapDeserializer.class)
     @JsonSerialize(contentAs=DefaultSourceGeometry.class, using= DefaultSourceGeometriesMapSerializer.class)

--- a/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
+++ b/src/main/java/com/targomo/client/api/StatisticTravelOptions.java
@@ -110,6 +110,8 @@ public class StatisticTravelOptions extends TravelOptions {
                 Objects.equals(getClosestSources, that.getClosestSources) &&
                 Objects.equals(omitIndividualStatistics, that.omitIndividualStatistics) &&
                 Objects.equals(inactiveSources, that.inactiveSources) &&
+                Objects.equals(inactiveGeometrySources, that.inactiveGeometrySources) &&
+                Objects.equals(inactiveSourceAddresses, that.inactiveSourceAddresses) &&
                 Objects.equals(cellIds, that.cellIds) &&
                 Objects.equals(multiGraphDomainStatisticGroupId, that.multiGraphDomainStatisticGroupId) &&
                 Objects.equals(multiGraphDomainStatisticCollectionId, that.multiGraphDomainStatisticCollectionId) &&
@@ -128,10 +130,10 @@ public class StatisticTravelOptions extends TravelOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), inactiveSources, useH3Reachability, useStatisticTargets, getClosestSources,
-                omitIndividualStatistics, cellIds, multiGraphDomainStatisticGroupId, multiGraphDomainStatisticCollectionId,
-                multiGraphLayerUnboundedStatistics, multiGraphReferencedStatisticIds, multiGraphTravelTimeApproximation,
-                statisticIds, chartInterval, statisticCollectionId,
+        return Objects.hash(super.hashCode(), inactiveSources, inactiveGeometrySources, inactiveSourceAddresses, useH3Reachability,
+                useStatisticTargets, getClosestSources, omitIndividualStatistics, cellIds, multiGraphDomainStatisticGroupId,
+                multiGraphDomainStatisticCollectionId, multiGraphLayerUnboundedStatistics, multiGraphReferencedStatisticIds,
+                multiGraphTravelTimeApproximation, statisticIds, chartInterval, statisticCollectionId,
                 multigraphCalculateGravitationPerReferenceId, returnOriginId, competingRoutingOptions,
                 routingAggregationType.ordinal(), multiGraphIgnoreRoutingErrorMessages);
     }
@@ -142,6 +144,10 @@ public class StatisticTravelOptions extends TravelOptions {
         builder.append(getClass().getName());
         builder.append("\n\tinactiveSources: ");
         builder.append(Arrays.toString(inactiveSources.entrySet().toArray()));
+        builder.append("\n\tinactiveGeometrySources: ");
+        builder.append(Arrays.toString(inactiveGeometrySources.entrySet().toArray()));
+        builder.append("\n\tinactiveSourceAddresses: ");
+        builder.append(Arrays.toString(inactiveSourceAddresses.entrySet().toArray()));
         builder.append("\n\tomitIndividualStatistics: ");
         builder.append(omitIndividualStatistics);
         builder.append("\n\tcellIds: ");

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -17,8 +17,6 @@ import com.targomo.client.api.request.RouteRequest;
 import com.targomo.client.api.request.TimeRequest;
 import com.targomo.client.api.statistic.PoiType;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 
 import javax.persistence.*;
 import java.io.Serializable;

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -608,9 +608,10 @@ public class TravelOptions implements Serializable {
     @Override
     public int hashCode() {
 
-        return Objects.hash(sources, sourceGeometries, sourceAddresses, targets, targetGeohashes, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
-                rushHour, travelTimes, travelType, elevationEnabled, appendTravelTimes, pointReduction, reverse,
-                minPolygonHoleSize, time, date, frame, arrivalOrDepartureDuration, recommendations, srid, polygonOrientationRule, decimalPrecision, buffer, simplify,
+        return Objects.hash(sources, sourceGeometries, sourceAddresses, targets, targetGeohashes, targetAddresses, bikeSpeed,
+                bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill, rushHour, travelTimes, travelType, elevationEnabled,
+                appendTravelTimes, pointReduction, reverse, minPolygonHoleSize, time, date, frame, arrivalOrDepartureDuration,
+                recommendations, srid, polygonOrientationRule, decimalPrecision, buffer, simplify,
                 intersectionMode, pathSerializer, polygonSerializerType, maxSnapDistance, intersectionGeometry, exclusionGeometry,
                 multiGraphEdgeClasses, multiGraphSerializationFormat,
                 multiGraphSerializationDecimalPrecision, multiGraphSerializationMaxGeometryCount,

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -50,6 +50,11 @@ public class TravelOptions implements Serializable {
     @Transient
     private Map<String,Coordinate> sources  = new HashMap<>();
 
+    @JsonDeserialize(contentAs=DefaultSourceAddress.class, using=DefaultSourceAddressMapDeserializer.class)
+    @JsonSerialize(contentAs=DefaultSourceAddress.class, using=DefaultSourceAddressMapSerializer.class)
+    @Transient
+    private Map<String, DefaultSourceAddress> sourceAddresses  = new HashMap<>();
+
     @JsonDeserialize(contentAs= DefaultSourceGeometry.class, using= DefaultSourceGeometriesMapDeserializer.class)
     @JsonSerialize(contentAs= DefaultSourceGeometry.class, using= DefaultSourceGeometriesMapSerializer.class)
     @Transient
@@ -382,6 +387,10 @@ public class TravelOptions implements Serializable {
         this.sourceGeometries.put(source.getId(), source);
     }
 
+    public void addSourceAddress(DefaultSourceAddress address) {
+        this.sourceAddresses.put(address.getH3Address(), address);
+    }
+
     /**
      * @param target Target coordinate
      */
@@ -485,6 +494,7 @@ public class TravelOptions implements Serializable {
                 onlyPrintReachablePoints == that.onlyPrintReachablePoints &&
                 Objects.equals(sources, that.sources) &&
                 Objects.equals(sourceGeometries, that.sourceGeometries) &&
+                Objects.equals(sourceAddresses, that.sourceAddresses) &&
                 Objects.equals(targets, that.targets) &&
                 Objects.equals(targetGeohashes, that.targetGeohashes) &&
                 Objects.equals(rushHour, that.rushHour) &&
@@ -590,7 +600,7 @@ public class TravelOptions implements Serializable {
     @Override
     public int hashCode() {
 
-        return Objects.hash(sources, sourceGeometries, targets, targetGeohashes, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
+        return Objects.hash(sources, sourceGeometries, sourceAddresses, targets, targetGeohashes, bikeSpeed, bikeUphill, bikeDownhill, walkSpeed, walkUphill, walkDownhill,
                 rushHour, travelTimes, travelType, elevationEnabled, appendTravelTimes, pointReduction, reverse,
                 minPolygonHoleSize, time, date, frame, arrivalOrDepartureDuration, recommendations, srid, polygonOrientationRule, decimalPrecision, buffer, simplify,
                 intersectionMode, pathSerializer, polygonSerializerType, maxSnapDistance, intersectionGeometry, exclusionGeometry,
@@ -642,6 +652,8 @@ public class TravelOptions implements Serializable {
         builder.append(sources != null ? toString(sources.entrySet(), maxLen) : null);
         builder.append(" {\n\tsourceGeometries: ");
         builder.append(sourceGeometries != null ? toString(sourceGeometries.entrySet(), maxLen) : null);
+        builder.append(" {\n\tsourceAddresses: ");
+        builder.append(sourceAddresses != null ? toString(sourceAddresses.entrySet(), maxLen) : null);
         builder.append("\n\ttargets: ");
         builder.append(targets != null ? toString(targets.entrySet(), maxLen) : null);
         builder.append("\n\ttargetGeohashes: ");

--- a/src/main/java/com/targomo/client/api/TravelOptions.java
+++ b/src/main/java/com/targomo/client/api/TravelOptions.java
@@ -68,6 +68,9 @@ public class TravelOptions implements Serializable {
     @Transient
     private List<String> targetGeohashes = new ArrayList<>();
 
+    @Transient
+    private List<String> targetAddresses = new ArrayList<>();
+
     @Column(name = "bike_speed")
     private double bikeSpeed         = 15.0;
 
@@ -321,6 +324,10 @@ public class TravelOptions implements Serializable {
         this.targetGeohashes.addAll(geohashes);
     }
 
+    public void addAllTargetAddresses(List<String> targetAddresses){
+        this.targetAddresses.addAll(targetAddresses);
+    }
+
     /**
      * This function will be removed in a future release.
      * Use maxEdgeWeight and edgeWeightType instead.
@@ -497,6 +504,7 @@ public class TravelOptions implements Serializable {
                 Objects.equals(sourceAddresses, that.sourceAddresses) &&
                 Objects.equals(targets, that.targets) &&
                 Objects.equals(targetGeohashes, that.targetGeohashes) &&
+                Objects.equals(targetGeohashes, that.targetAddresses) &&
                 Objects.equals(rushHour, that.rushHour) &&
                 Objects.equals(travelTimes, that.travelTimes) &&
                 travelType == that.travelType &&
@@ -658,6 +666,8 @@ public class TravelOptions implements Serializable {
         builder.append(targets != null ? toString(targets.entrySet(), maxLen) : null);
         builder.append("\n\ttargetGeohashes: ");
         builder.append(targetGeohashes != null ? toString(targetGeohashes, maxLen) : null);
+        builder.append("\n\ttargetAddresses: ");
+        builder.append(targetAddresses != null ? toString(targetAddresses, maxLen) : null);
         builder.append("\n\tbikeSpeed: ");
         builder.append(bikeSpeed);
         builder.append("\n\tbikeUphill: ");

--- a/src/main/java/com/targomo/client/api/geo/DefaultSourceAddress.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultSourceAddress.java
@@ -1,0 +1,78 @@
+package com.targomo.client.api.geo;
+
+import com.targomo.client.api.enums.TravelType;
+import com.targomo.client.api.pojo.LocationProperties;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+/**
+ * AbstractClass for dealing with Source/Target H3 Addresses
+ */
+@MappedSuperclass @Getter @Setter
+public class DefaultSourceAddress extends AbstractLocation implements Location {
+
+	@Id
+	@Column(name = "identifier")
+	@GeneratedValue(strategy= GenerationType.TABLE)
+	private long identifier;
+
+	@Column(name = "travel_type")
+	private TravelType travelType;
+
+	private String h3Address;
+
+	// needed for jackson
+	public DefaultSourceAddress(){
+		super();
+	}
+
+	public DefaultSourceAddress(final String h3Address, TravelType travelType, LocationProperties locationProperties) {
+		super(null, locationProperties);
+		this.h3Address = h3Address;
+		this.travelType = travelType;
+	}
+
+	public DefaultSourceAddress(final String h3Address, final LocationProperties locationProperties) {
+		this(h3Address, null, locationProperties);
+	}
+
+	public DefaultSourceAddress(String h3Address, TravelType travelType){
+		this(h3Address, travelType, null);
+	}
+
+	public DefaultSourceAddress(String h3Address) {
+		this(h3Address, null, null);
+	}
+
+	/**
+	 * Returns a JSON String representation of the Coordinate with ID, x and y values.
+	 * @return JSON representation of the coordinate
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append(getClass().getName());
+		builder.append(" {\n\th3Address: ");
+		builder.append(h3Address);
+		builder.append("\n}\n");
+		return builder.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		DefaultSourceAddress that = (DefaultSourceAddress) o;
+
+		return Objects.equals(h3Address, that.h3Address);
+	}
+
+	@Override
+	public int hashCode() {
+		return h3Address.hashCode();
+	}
+}

--- a/src/main/java/com/targomo/client/api/geo/DefaultSourceCoordinate.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultSourceCoordinate.java
@@ -1,6 +1,7 @@
 package com.targomo.client.api.geo;
 
 import com.targomo.client.api.enums.TravelType;
+import com.targomo.client.api.exception.TargomoClientRuntimeException;
 import com.targomo.client.api.pojo.LocationProperties;
 
 import javax.persistence.*;
@@ -90,6 +91,24 @@ public class DefaultSourceCoordinate extends AbstractCoordinate {
 	public long getIdentifier() { return identifier; }
 
 	public void setIdentifier(long id) { this.identifier = id; }
+
+	/**
+	 * Not implemented, will throw exception.
+	 * @throws TargomoClientRuntimeException any time this method is called.
+	 */
+	@Override
+	public String getH3Address() {
+		throw new TargomoClientRuntimeException("Not implemented.");
+	}
+
+	/**
+	 * Not implemented, will throw exception.
+	 * @throws TargomoClientRuntimeException any time this method is called.
+	 */
+	@Override
+	public void setH3Address(final String h3Address) {
+		throw new TargomoClientRuntimeException("Not implemented.");
+	}
 
     /**
 	 * Specify a travel type for the source coordinate.

--- a/src/main/java/com/targomo/client/api/geo/DefaultSourceCoordinate.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultSourceCoordinate.java
@@ -92,24 +92,6 @@ public class DefaultSourceCoordinate extends AbstractCoordinate {
 
 	public void setIdentifier(long id) { this.identifier = id; }
 
-	/**
-	 * Not implemented, will throw exception.
-	 * @throws TargomoClientRuntimeException any time this method is called.
-	 */
-	@Override
-	public String getH3Address() {
-		throw new TargomoClientRuntimeException("Not implemented.");
-	}
-
-	/**
-	 * Not implemented, will throw exception.
-	 * @throws TargomoClientRuntimeException any time this method is called.
-	 */
-	@Override
-	public void setH3Address(final String h3Address) {
-		throw new TargomoClientRuntimeException("Not implemented.");
-	}
-
     /**
 	 * Specify a travel type for the source coordinate.
 	 * @param travelType TravelType to be associated with the source coordinate.

--- a/src/main/java/com/targomo/client/api/geo/DefaultSourceGeometry.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultSourceGeometry.java
@@ -104,24 +104,6 @@ public class DefaultSourceGeometry extends AbstractGeometry {
         this.travelType = travelType;
     }
 
-    /**
-     * Not implemented, will throw exception.
-     * @throws TargomoClientRuntimeException any time this method is called.
-     */
-    @Override
-    public String getH3Address() {
-        throw new TargomoClientRuntimeException("Not implemented.");
-    }
-
-    /**
-     * Not implemented, will throw exception.
-     * @throws TargomoClientRuntimeException any time this method is called.
-     */
-    @Override
-    public void setH3Address(final String h3Address) {
-        throw new TargomoClientRuntimeException("Not implemented.");
-    }
-
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/targomo/client/api/geo/DefaultSourceGeometry.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultSourceGeometry.java
@@ -1,6 +1,7 @@
 package com.targomo.client.api.geo;
 
 import com.targomo.client.api.enums.TravelType;
+import com.targomo.client.api.exception.TargomoClientRuntimeException;
 import com.targomo.client.api.pojo.LocationProperties;
 
 import javax.persistence.*;
@@ -101,6 +102,24 @@ public class DefaultSourceGeometry extends AbstractGeometry {
     @Override
     public void setTravelType(final TravelType travelType) {
         this.travelType = travelType;
+    }
+
+    /**
+     * Not implemented, will throw exception.
+     * @throws TargomoClientRuntimeException any time this method is called.
+     */
+    @Override
+    public String getH3Address() {
+        throw new TargomoClientRuntimeException("Not implemented.");
+    }
+
+    /**
+     * Not implemented, will throw exception.
+     * @throws TargomoClientRuntimeException any time this method is called.
+     */
+    @Override
+    public void setH3Address(final String h3Address) {
+        throw new TargomoClientRuntimeException("Not implemented.");
     }
 
     @Override

--- a/src/main/java/com/targomo/client/api/geo/DefaultTargetCoordinate.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultTargetCoordinate.java
@@ -29,6 +29,24 @@ public class DefaultTargetCoordinate extends AbstractCoordinate {
 	 * @throws TargomoClientRuntimeException any time this method is called.
 	 */
 	@Override
+	public String getH3Address() {
+		throw new TargomoClientRuntimeException("Not implemented.");
+	}
+
+	/**
+	 * Not implemented, will throw exception.
+	 * @throws TargomoClientRuntimeException any time this method is called.
+	 */
+	@Override
+	public void setH3Address(final String h3Address) {
+		throw new TargomoClientRuntimeException("Not implemented.");
+	}
+
+	/**
+	 * Not implemented, will throw exception.
+	 * @throws TargomoClientRuntimeException any time this method is called.
+	 */
+	@Override
 	public TravelType getTravelType() {
 		throw new TargomoClientRuntimeException("Not implemented.");
 	}

--- a/src/main/java/com/targomo/client/api/geo/DefaultTargetCoordinate.java
+++ b/src/main/java/com/targomo/client/api/geo/DefaultTargetCoordinate.java
@@ -29,24 +29,6 @@ public class DefaultTargetCoordinate extends AbstractCoordinate {
 	 * @throws TargomoClientRuntimeException any time this method is called.
 	 */
 	@Override
-	public String getH3Address() {
-		throw new TargomoClientRuntimeException("Not implemented.");
-	}
-
-	/**
-	 * Not implemented, will throw exception.
-	 * @throws TargomoClientRuntimeException any time this method is called.
-	 */
-	@Override
-	public void setH3Address(final String h3Address) {
-		throw new TargomoClientRuntimeException("Not implemented.");
-	}
-
-	/**
-	 * Not implemented, will throw exception.
-	 * @throws TargomoClientRuntimeException any time this method is called.
-	 */
-	@Override
 	public TravelType getTravelType() {
 		throw new TargomoClientRuntimeException("Not implemented.");
 	}

--- a/src/main/java/com/targomo/client/api/geo/Location.java
+++ b/src/main/java/com/targomo/client/api/geo/Location.java
@@ -33,18 +33,6 @@ public interface Location {
     public void setId(final String id);
 
     /**
-     * Get the H3 address that represents a coordinate.
-     * @return The H3 Address
-     */
-    public String getH3Address();
-
-    /**
-     * Sets the H3 address that represents a coordinate.
-     * @param h3Address The H3 Address
-     */
-    public void setH3Address(final String h3Address);
-
-    /**
      * Get the properties of a location
      * @return Location Properties
      */

--- a/src/main/java/com/targomo/client/api/geo/Location.java
+++ b/src/main/java/com/targomo/client/api/geo/Location.java
@@ -33,6 +33,18 @@ public interface Location {
     public void setId(final String id);
 
     /**
+     * Get the H3 address that represents a coordinate.
+     * @return The H3 Address
+     */
+    public String getH3Address();
+
+    /**
+     * Sets the H3 address that represents a coordinate.
+     * @param h3Address The H3 Address
+     */
+    public void setH3Address(final String h3Address);
+
+    /**
      * Get the properties of a location
      * @return Location Properties
      */

--- a/src/main/java/com/targomo/client/api/json/AbstractLocationMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/AbstractLocationMapDeserializer.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 public abstract class AbstractLocationMapDeserializer<K extends Location> extends JsonDeserializer<Map<String, K>> {
 
-    private ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper();
     
     public Map<String, K> deserialize(String key, JsonParser jsonParser, Class<K> deserializationClass)
             throws IOException {

--- a/src/main/java/com/targomo/client/api/json/AbstractLocationMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/AbstractLocationMapDeserializer.java
@@ -1,0 +1,35 @@
+package com.targomo.client.api.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.targomo.client.api.geo.Location;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by Gideon Cohen
+ */
+
+public abstract class AbstractLocationMapDeserializer<K extends Location> extends JsonDeserializer<Map<String, K>> {
+
+    private ObjectMapper mapper = new ObjectMapper();
+    
+    public Map<String, K> deserialize(String key, JsonParser jsonParser, Class<K> deserializationClass)
+            throws IOException {
+        
+        JsonNode locationArray = jsonParser.getCodec().readTree(jsonParser);
+
+        Map<String,K> locations = new HashMap<>();
+
+        for (JsonNode coordinateNode : locationArray) {
+            locations.put(coordinateNode.get(key).asText(),
+                mapper.readValue(coordinateNode.toString(), deserializationClass));
+        }
+
+        return locations;
+    }
+}

--- a/src/main/java/com/targomo/client/api/json/AbstractSourceMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/AbstractSourceMapSerializer.java
@@ -1,0 +1,26 @@
+package com.targomo.client.api.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.targomo.client.api.geo.Location;
+
+import java.io.IOException;
+
+/**
+ * Created by Gideon Cohen
+ */
+public abstract class AbstractSourceMapSerializer extends JsonSerializer {
+
+
+    public void writeExtraData(Location location, JsonGenerator jsonGenerator) throws IOException {
+        if ( location.getTravelType() != null ) jsonGenerator.writeStringField("tm", location.getTravelType().toString());
+        if( location.getProperties() != null){
+            jsonGenerator.writeFieldName("aggregationInputParameters");
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeNumberField("inputFactor", location.getProperties().getInputFactor());
+            jsonGenerator.writeNumberField("gravitationAttractionStrength", location.getProperties().getGravitationAttractionStrength());
+            jsonGenerator.writeBooleanField("gravitationPositiveInfluence", location.getProperties().getGravitationPositiveInfluence());
+            jsonGenerator.writeEndObject();
+        }
+    }
+}

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapDeserializer.java
@@ -2,40 +2,22 @@ package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.targomo.client.api.geo.Coordinate;
 import com.targomo.client.api.geo.DefaultSourceAddress;
-import com.targomo.client.api.geo.DefaultSourceCoordinate;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Created by gerb on 01/02/2017.
+ * Created by Gideon Cohen
  */
 
-public class DefaultSourceAddressMapDeserializer extends JsonDeserializer<Map<String, DefaultSourceAddress>> {
-
-    private ObjectMapper mapper = new ObjectMapper();
+public class DefaultSourceAddressMapDeserializer extends AbstractLocationMapDeserializer<DefaultSourceAddress> {
 
     public DefaultSourceAddressMapDeserializer() {}
 
     @Override
     public Map<String, DefaultSourceAddress> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
-
-        JsonNode coordinatesArray = jsonParser.getCodec().readTree(jsonParser);
-
-        Map<String,DefaultSourceAddress> addresses = new HashMap<>();
-
-        for (JsonNode coordinateNode : coordinatesArray) {
-            addresses.put(coordinateNode.get("h3Address").asText(),
-                mapper.readValue(coordinateNode.toString(), DefaultSourceAddress.class));
-        }
-
-        return addresses;
+        return deserialize("h3Address", jsonParser, DefaultSourceAddress.class);
     }
 }

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapDeserializer.java
@@ -1,0 +1,41 @@
+package com.targomo.client.api.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.targomo.client.api.geo.Coordinate;
+import com.targomo.client.api.geo.DefaultSourceAddress;
+import com.targomo.client.api.geo.DefaultSourceCoordinate;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by gerb on 01/02/2017.
+ */
+
+public class DefaultSourceAddressMapDeserializer extends JsonDeserializer<Map<String, DefaultSourceAddress>> {
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    public DefaultSourceAddressMapDeserializer() {}
+
+    @Override
+    public Map<String, DefaultSourceAddress> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+
+        JsonNode coordinatesArray = jsonParser.getCodec().readTree(jsonParser);
+
+        Map<String,DefaultSourceAddress> addresses = new HashMap<>();
+
+        for (JsonNode coordinateNode : coordinatesArray) {
+            addresses.put(coordinateNode.get("h3Address").asText(),
+                mapper.readValue(coordinateNode.toString(), DefaultSourceAddress.class));
+        }
+
+        return addresses;
+    }
+}

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
@@ -10,27 +10,18 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Created by gerb on 01/03/2017.
+ * Created by Gideon Cohen
  */
-public class DefaultSourceAddressMapSerializer extends JsonSerializer {
+public class DefaultSourceAddressMapSerializer extends AbstractSourceMapSerializer {
     @Override
     public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
 
-        jsonGenerator.writeStartArray(); // [
+        jsonGenerator.writeStartArray();
 
         for ( Map.Entry<String, DefaultSourceAddress> entry : ((Map<String, DefaultSourceAddress>) o).entrySet())  {
-
             jsonGenerator.writeStartObject();
             jsonGenerator.writeStringField("h3Address", entry.getKey());
-            if ( entry.getValue().getTravelType() != null ) jsonGenerator.writeStringField("tm", entry.getValue().getTravelType().toString());
-            if( entry.getValue().getProperties() != null){
-                jsonGenerator.writeFieldName("aggregationInputParameters");
-                jsonGenerator.writeStartObject();
-                jsonGenerator.writeNumberField("inputFactor", entry.getValue().getProperties().getInputFactor());
-                jsonGenerator.writeNumberField("gravitationAttractionStrength", entry.getValue().getProperties().getGravitationAttractionStrength());
-                jsonGenerator.writeBooleanField("gravitationPositiveInfluence", entry.getValue().getProperties().getGravitationPositiveInfluence());
-                jsonGenerator.writeEndObject();
-            }
+            writeExtraData(entry.getValue(), jsonGenerator);
             jsonGenerator.writeEndObject();
         }
 

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
@@ -1,10 +1,8 @@
 package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.targomo.client.api.geo.DefaultSourceAddress;
-import com.targomo.client.api.geo.DefaultSourceCoordinate;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceAddressMapSerializer.java
@@ -1,0 +1,39 @@
+package com.targomo.client.api.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.targomo.client.api.geo.DefaultSourceAddress;
+import com.targomo.client.api.geo.DefaultSourceCoordinate;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Created by gerb on 01/03/2017.
+ */
+public class DefaultSourceAddressMapSerializer extends JsonSerializer {
+    @Override
+    public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+
+        jsonGenerator.writeStartArray(); // [
+
+        for ( Map.Entry<String, DefaultSourceAddress> entry : ((Map<String, DefaultSourceAddress>) o).entrySet())  {
+
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("h3Address", entry.getKey());
+            if ( entry.getValue().getTravelType() != null ) jsonGenerator.writeStringField("tm", entry.getValue().getTravelType().toString());
+            if( entry.getValue().getProperties() != null){
+                jsonGenerator.writeFieldName("aggregationInputParameters");
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeNumberField("inputFactor", entry.getValue().getProperties().getInputFactor());
+                jsonGenerator.writeNumberField("gravitationAttractionStrength", entry.getValue().getProperties().getGravitationAttractionStrength());
+                jsonGenerator.writeBooleanField("gravitationPositiveInfluence", entry.getValue().getProperties().getGravitationPositiveInfluence());
+                jsonGenerator.writeEndObject();
+            }
+            jsonGenerator.writeEndObject();
+        }
+
+        jsonGenerator.writeEndArray(); // ]
+    }
+}

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapDeserializer.java
@@ -2,39 +2,22 @@ package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.targomo.client.api.geo.Coordinate;
 import com.targomo.client.api.geo.DefaultSourceCoordinate;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
  * Created by gerb on 01/02/2017.
  */
 
-public class DefaultSourceCoordinateMapDeserializer extends JsonDeserializer<Map<String, Coordinate>> {
-
-    private ObjectMapper mapper = new ObjectMapper();
+public class DefaultSourceCoordinateMapDeserializer extends AbstractLocationMapDeserializer<DefaultSourceCoordinate> {
 
     public DefaultSourceCoordinateMapDeserializer() {}
 
     @Override
-    public Map<String, Coordinate> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+    public Map<String, DefaultSourceCoordinate> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
-
-        JsonNode coordinatesArray = jsonParser.getCodec().readTree(jsonParser);
-
-        Map<String,Coordinate> coordinates = new HashMap<>();
-
-        for (JsonNode coordinateNode : coordinatesArray) {
-            coordinates.put(coordinateNode.get("id").asText(),
-                mapper.readValue(coordinateNode.toString(), DefaultSourceCoordinate.class));
-        }
-
-        return coordinates;
+        return deserialize("id", jsonParser, DefaultSourceCoordinate.class);
     }
 }

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapSerializer.java
@@ -11,27 +11,18 @@ import java.util.Map;
 /**
  * Created by gerb on 01/03/2017.
  */
-public class DefaultSourceCoordinateMapSerializer extends JsonSerializer {
+public class DefaultSourceCoordinateMapSerializer extends AbstractSourceMapSerializer {
     @Override
     public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
 
         jsonGenerator.writeStartArray(); // [
 
         for ( Map.Entry<String, DefaultSourceCoordinate> entry : ((Map<String, DefaultSourceCoordinate>) o).entrySet())  {
-
             jsonGenerator.writeStartObject();
             jsonGenerator.writeStringField("id", entry.getKey());
-            if ( entry.getValue().getTravelType() != null ) jsonGenerator.writeStringField("tm", entry.getValue().getTravelType().toString());
             jsonGenerator.writeNumberField("y", entry.getValue().getY());
             jsonGenerator.writeNumberField("x", entry.getValue().getX());
-            if( entry.getValue().getProperties() != null){
-                jsonGenerator.writeFieldName("aggregationInputParameters");
-                jsonGenerator.writeStartObject();
-                jsonGenerator.writeNumberField("inputFactor", entry.getValue().getProperties().getInputFactor());
-                jsonGenerator.writeNumberField("gravitationAttractionStrength", entry.getValue().getProperties().getGravitationAttractionStrength());
-                jsonGenerator.writeBooleanField("gravitationPositiveInfluence", entry.getValue().getProperties().getGravitationPositiveInfluence());
-                jsonGenerator.writeEndObject();
-            }
+            writeExtraData(entry.getValue(), jsonGenerator);
             jsonGenerator.writeEndObject();
         }
 

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceCoordinateMapSerializer.java
@@ -1,7 +1,6 @@
 package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.targomo.client.api.geo.DefaultSourceCoordinate;
 

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapDeserializer.java
@@ -2,37 +2,20 @@ package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.targomo.client.api.geo.AbstractGeometry;
 import com.targomo.client.api.geo.DefaultSourceGeometry;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
  * @author gideon
  */
-public class DefaultSourceGeometriesMapDeserializer extends JsonDeserializer<Map<String, AbstractGeometry>> {
-    private ObjectMapper mapper = new ObjectMapper();
-
+public class DefaultSourceGeometriesMapDeserializer extends AbstractLocationMapDeserializer<DefaultSourceGeometry> {
     public DefaultSourceGeometriesMapDeserializer() {}
 
     @Override
-    public Map<String, AbstractGeometry> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+    public Map<String, DefaultSourceGeometry> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
             throws IOException {
-
-        JsonNode polygonsArray = jsonParser.getCodec().readTree(jsonParser);
-
-        Map<String, AbstractGeometry> polygons = new HashMap<>();
-
-        for (JsonNode polygonNode : polygonsArray) {
-            polygons.put(polygonNode.get("id").asText(),
-                    mapper.readValue(polygonNode.toString(), DefaultSourceGeometry.class));
-        }
-
-        return polygons;
+        return deserialize("id", jsonParser, DefaultSourceGeometry.class);
     }
 }

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapSerializer.java
@@ -1,7 +1,6 @@
 package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.targomo.client.api.geo.DefaultSourceGeometry;
 

--- a/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapSerializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultSourceGeometriesMapSerializer.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * @author gideon
  */
-public class DefaultSourceGeometriesMapSerializer extends JsonSerializer {
+public class DefaultSourceGeometriesMapSerializer extends AbstractSourceMapSerializer {
     @Override
     public void serialize(Object o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
 
@@ -21,18 +21,10 @@ public class DefaultSourceGeometriesMapSerializer extends JsonSerializer {
 
             jsonGenerator.writeStartObject(); // {
             jsonGenerator.writeStringField("id", entry.getKey());
-            if ( entry.getValue().getTravelType() != null ) jsonGenerator.writeStringField("tm", entry.getValue().getTravelType().toString());
             jsonGenerator.writeStringField("data", entry.getValue().getData());
             jsonGenerator.writeNumberField("crs", entry.getValue().getCrs());
             jsonGenerator.writeBooleanField("routeFromCentroid", entry.getValue().isRouteFromCentroid());
-            if( entry.getValue().getProperties() != null){
-                jsonGenerator.writeFieldName("aggregationInputParameters");
-                jsonGenerator.writeStartObject();
-                jsonGenerator.writeNumberField("inputFactor", entry.getValue().getProperties().getInputFactor());
-                jsonGenerator.writeNumberField("gravitationAttractionStrength", entry.getValue().getProperties().getGravitationAttractionStrength());
-                jsonGenerator.writeBooleanField("gravitationPositiveInfluence", entry.getValue().getProperties().getGravitationPositiveInfluence());
-                jsonGenerator.writeEndObject();
-            }
+            writeExtraData(entry.getValue(), jsonGenerator);
             jsonGenerator.writeEndObject(); // }
         }
 

--- a/src/main/java/com/targomo/client/api/json/DefaultTargetCoordinateMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultTargetCoordinateMapDeserializer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.targomo.client.api.geo.Coordinate;
+import com.targomo.client.api.geo.DefaultSourceGeometry;
 import com.targomo.client.api.geo.DefaultTargetCoordinate;
 
 import java.io.IOException;
@@ -17,25 +18,15 @@ import java.util.Map;
  * Created by gerb on 01/02/2017.
  */
 
-public class DefaultTargetCoordinateMapDeserializer extends JsonDeserializer<Map<String, Coordinate>> {
+public class DefaultTargetCoordinateMapDeserializer extends AbstractLocationMapDeserializer<DefaultTargetCoordinate> {
 
     private ObjectMapper mapper = new ObjectMapper();
 
     public DefaultTargetCoordinateMapDeserializer() {}
 
     @Override
-    public Map<String, Coordinate> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
-            throws JsonProcessingException, IOException {
-
-        JsonNode coordinatesArray = jsonParser.getCodec().readTree(jsonParser);
-
-        Map<String,Coordinate> coordinates = new HashMap<>();
-
-        for (JsonNode coordinateNode : coordinatesArray) {
-            coordinates.put(coordinateNode.get("id").asText(),
-                    mapper.readValue(coordinateNode.toString(), DefaultTargetCoordinate.class));
-        }
-
-        return coordinates;
+    public Map<String, DefaultTargetCoordinate> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
+        return deserialize("id", jsonParser, DefaultTargetCoordinate.class);
     }
 }

--- a/src/main/java/com/targomo/client/api/json/DefaultTargetCoordinateMapDeserializer.java
+++ b/src/main/java/com/targomo/client/api/json/DefaultTargetCoordinateMapDeserializer.java
@@ -1,17 +1,11 @@
 package com.targomo.client.api.json;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.targomo.client.api.geo.Coordinate;
-import com.targomo.client.api.geo.DefaultSourceGeometry;
 import com.targomo.client.api.geo.DefaultTargetCoordinate;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
+++ b/src/main/java/com/targomo/client/api/request/EdgeStatisticsRequest.java
@@ -8,7 +8,6 @@ import com.targomo.client.api.exception.TargomoClientRuntimeException;
 import com.targomo.client.api.pojo.EdgeStatisticsRequestOptions;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONException;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;

--- a/src/main/java/com/targomo/client/api/request/MultiGraphRequest.java
+++ b/src/main/java/com/targomo/client/api/request/MultiGraphRequest.java
@@ -9,7 +9,6 @@ import com.targomo.jackson.datatype.trove.TroveModule;
 import com.targomo.client.api.enums.MultiGraphSerializationFormat;
 import com.targomo.client.api.response.MultiGraphResponse;
 import com.targomo.client.api.response.MultiGraphResponse.*;
-import org.apache.commons.collections.map.MultiValueMap;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;

--- a/src/main/java/com/targomo/client/api/request/RouteRequest.java
+++ b/src/main/java/com/targomo/client/api/request/RouteRequest.java
@@ -9,14 +9,12 @@ import com.targomo.client.api.util.IOUtil;
 import com.targomo.client.api.util.JsonUtil;
 import com.targomo.client.api.TravelOptions;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-import java.util.Objects;
 
 /**
  * Generates possible route from sources to targets.

--- a/src/main/java/com/targomo/client/api/request/StatisticsRequest.java
+++ b/src/main/java/com/targomo/client/api/request/StatisticsRequest.java
@@ -12,7 +12,6 @@ import com.targomo.client.api.response.StatisticsGeometryValuesResponse;
 import com.targomo.client.api.response.StatisticsResponse;
 import com.targomo.client.api.util.IOUtil;
 import com.targomo.client.api.util.JsonUtil;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/targomo/client/api/request/TargomoRequest.java
+++ b/src/main/java/com/targomo/client/api/request/TargomoRequest.java
@@ -10,7 +10,6 @@ import com.targomo.client.api.request.ssl.SslClientGenerator;
 import com.targomo.client.api.response.DefaultResponse;
 import com.targomo.client.api.response.ResponseCode;
 import com.targomo.client.api.util.IOUtil;
-import com.targomo.client.api.util.JsonUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.ws.rs.HttpMethod;

--- a/src/main/java/com/targomo/client/api/request/TimeVectorRequest.java
+++ b/src/main/java/com/targomo/client/api/request/TimeVectorRequest.java
@@ -3,7 +3,6 @@ package com.targomo.client.api.request;
 import com.targomo.client.api.TravelOptions;
 import com.targomo.client.api.exception.ResponseErrorException;
 import com.targomo.client.api.exception.TargomoClientException;
-import com.targomo.client.api.response.MultiGraphResponse;
 import com.targomo.client.api.response.TimeVectorResponse;
 
 import javax.ws.rs.HttpMethod;

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -7,6 +7,7 @@ import com.targomo.client.api.enums.TravelType;
 import com.targomo.client.api.exception.TargomoClientException;
 import com.targomo.client.api.geo.AbstractGeometry;
 import com.targomo.client.api.geo.Coordinate;
+import com.targomo.client.api.geo.DefaultSourceAddress;
 import com.targomo.client.api.pojo.AggregationConfiguration;
 import com.targomo.client.api.pojo.AggregationInputParameters;
 import com.targomo.client.api.pojo.Geometry;
@@ -155,6 +156,9 @@ public final class RequestConfigurator {
 
             if (travelOptions.getSourceGeometries() != null && !travelOptions.getSourceGeometries().isEmpty())
                 JSONBuilder.append(config, SOURCE_GEOMETRIES, getSourceGeometries(travelOptions));
+
+            if (travelOptions.getSourceAddresses() != null && !travelOptions.getSourceAddresses().isEmpty())
+                JSONBuilder.append(config, SOURCE_ADDRESSES, getSourceAddresses(travelOptions));
 
             if (travelOptions.getTargets() != null && !travelOptions.getTargets().isEmpty())
                 JSONBuilder.append(config, TARGETS, getTargets(travelOptions));
@@ -548,6 +552,23 @@ public final class RequestConfigurator {
         return sourceGeometries;
     }
 
+    private static JSONArray getSourceAddresses(final TravelOptions travelOptions) throws JSONException {
+        JSONArray sourceAddresses = new JSONArray();
+        for (DefaultSourceAddress src : travelOptions.getSourceAddresses().values()) {
+
+            TravelType travelType = getTravelType(travelOptions, src);
+            JSONObject travelMode = getTravelMode(travelOptions, travelType);
+
+            JSONObject source = new JSONObject()
+                    .put(H3_ADDRESS, src.getH3Address());
+
+            addTransportationMode(travelOptions, src, source, travelType, travelMode);
+
+            sourceAddresses.put(source);
+        }
+        return sourceAddresses;
+    }
+
 
     private static StringBuilder getTargets(final TravelOptions travelOptions) {
         StringBuilder targetsBuilder = new StringBuilder().append("[");
@@ -680,6 +701,7 @@ public final class RequestConfigurator {
                     .put(DATA, geometry.getData())
                     .put(ROUTE_FROM_CENTROID, geometry.isRouteFromCentroid());
         }
+        addTransportationMode(travelOptions, src, source, travelType, travelMode);
         source.put(TRANSPORT_MODE, new JSONObject().put(travelType.toString(), travelMode));
 
         if(src.getProperties() != null){
@@ -694,6 +716,21 @@ public final class RequestConfigurator {
             source.put(REVERSE, travelOptions.getReverse());
         }
         return source;
+    }
+
+    private static void addTransportationMode(TravelOptions travelOptions, com.targomo.client.api.geo.Location src, JSONObject source, TravelType travelType, JSONObject travelMode) throws JSONException {
+        source.put(TRANSPORT_MODE, new JSONObject().put(travelType.toString(), travelMode));
+        if(src.getProperties() != null){
+            source.put(PROPERTIES, new JSONObject()
+                    .put(MULTIGRAPH_AGGREGATION_INPUT_PARAMETERS_FACTOR, src.getProperties().getInputFactor())
+                    .put(MULTIGRAPH_AGGREGATION_INPUT_PARAMETERS_GRAVITATION_ATTRACTION_STRENGTH, src.getProperties().getGravitationAttractionStrength())
+                    .put(MULTIGRAPH_AGGREGATION_INPUT_PARAMETERS_GRAVITATION_POSITIVE_INFLUENCE, src.getProperties().getGravitationPositiveInfluence())
+            );
+        }
+
+        if (travelOptions.getReverse() != null) {
+            source.put(REVERSE, travelOptions.getReverse());
+        }
     }
 
     /**

--- a/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
+++ b/src/main/java/com/targomo/client/api/request/config/RequestConfigurator.java
@@ -166,6 +166,9 @@ public final class RequestConfigurator {
             if (travelOptions.getTargetGeohashes() != null && !travelOptions.getTargetGeohashes().isEmpty())
                 JSONBuilder.appendStringList(config, TARGET_GEOHASHES, travelOptions.getTargetGeohashes());
 
+            if (travelOptions.getTargetAddresses() != null && !travelOptions.getTargetAddresses().isEmpty())
+                JSONBuilder.appendStringList(config, TARGET_ADDRESSES, travelOptions.getTargetAddresses());
+
             if (travelOptions.getPathSerializer() != null)
                 JSONBuilder.appendString(config, PATH_SERIALIZER, travelOptions.getPathSerializer().getPathSerializerName());
 

--- a/src/main/java/com/targomo/client/api/response/DefaultResponse.java
+++ b/src/main/java/com/targomo/client/api/response/DefaultResponse.java
@@ -2,7 +2,6 @@ package com.targomo.client.api.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.targomo.client.api.TravelOptions;
-import com.targomo.client.api.exception.TargomoClientException;
 
 /**
  *

--- a/src/main/java/com/targomo/client/api/response/PolygonResponse.java
+++ b/src/main/java/com/targomo/client/api/response/PolygonResponse.java
@@ -1,7 +1,6 @@
 package com.targomo.client.api.response;
 
 import com.targomo.client.api.TravelOptions;
-import org.hsqldb.error.ErrorCode;
 import org.json.JSONObject;
 
 public class PolygonResponse {

--- a/src/main/java/com/targomo/client/api/response/TimeResponse.java
+++ b/src/main/java/com/targomo/client/api/response/TimeResponse.java
@@ -13,8 +13,6 @@ import org.json.JSONObject;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class TimeResponse {

--- a/src/test/java/com/targomo/client/api/request/MultiGraphRequestTest.java
+++ b/src/test/java/com/targomo/client/api/request/MultiGraphRequestTest.java
@@ -11,8 +11,6 @@ import com.targomo.client.api.request.ssl.SslClientGenerator;
 import com.targomo.client.api.response.MultiGraphResponse;
 import com.targomo.client.api.response.MultiGraphResponse.*;
 import com.targomo.client.api.response.ResponseCode;
-import com.targomo.client.api.util.CollectionUtils;
-import com.targomo.client.api.util.GeojsonUtil;
 import com.targomo.client.api.util.IOUtil;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.message.GZipEncoder;

--- a/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
+++ b/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
+++ b/src/test/java/com/targomo/client/api/request/config/RequestConfiguratorTest.java
@@ -322,7 +322,17 @@ public class RequestConfiguratorTest {
         DefaultSourceAddress sourceAddress = parsed.getSourceAddresses().get(address);
         Assert.assertEquals(address, sourceAddress.getH3Address());
         Assert.assertEquals(TravelType.WALK, sourceAddress.getTravelType());
+    }
 
+    @Test
+    public void readTargetAddressWithJackson() throws IOException {
+        String address = "testh3address";
+        TravelOptions parsed = new ObjectMapper()
+                .readValue( "{ \"targetAddresses\" : [ \"" + address + "\" ] }",
+                        TravelOptions.class);
+
+        Assert.assertEquals(1, parsed.getTargetAddresses().size());
+        Assert.assertEquals(address, parsed.getTargetAddresses().get(0));
     }
 
     @Test
@@ -331,15 +341,18 @@ public class RequestConfiguratorTest {
         options.setSourceAddresses(new HashMap<>());
         Stream.of("address1", "address2").forEach(addr ->
                 options.getSourceAddresses().put(addr, new DefaultSourceAddress(addr, TravelType.CAR)));
+        options.setTargetAddresses(Arrays.asList("address3", "address4"));
 
         // Run configurator && get object
         String cfg = RequestConfigurator.getConfig(options);
-
         JSONObject actualObject = new JSONObject(cfg);
+        System.out.println(actualObject);
+
         String sampleJson = IOUtils.toString(getClass().getClassLoader().getResourceAsStream("data/RequestWithH3Addresses.json"));
         JSONObject sampleObject = new JSONObject(sampleJson);
+
         Assert.assertEquals(sampleObject.getString(Constants.SOURCE_ADDRESSES), actualObject.getString(Constants.SOURCE_ADDRESSES));
-        System.out.println(cfg);
+        Assert.assertEquals(sampleObject.getString(Constants.TARGET_ADDRESSES), actualObject.getString(Constants.TARGET_ADDRESSES));
     }
 
     @Test

--- a/src/test/java/com/targomo/client/api/util/CurlUtilTest.java
+++ b/src/test/java/com/targomo/client/api/util/CurlUtilTest.java
@@ -2,15 +2,10 @@ package com.targomo.client.api.util;
 
 import org.junit.Test;
 
-import javax.ws.rs.core.Response;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CurlUtilTest {
 

--- a/src/test/resources/data/RequestWithH3Addresses.json
+++ b/src/test/resources/data/RequestWithH3Addresses.json
@@ -1,0 +1,47 @@
+{
+  "polygon": {
+    "pointReduction": true,
+    "intersectionMode": "UNION",
+    "values": [
+      600,
+      1200,
+      1800
+    ],
+    "minPolygonHoleSize": 100000000,
+    "serializer": "json"
+  },
+  "intersectionMode": "UNION",
+  "sourceAddresses": [
+    {
+      "h3Address": "address2",
+      "tm": {
+        "car": {
+          "walkSpeed": 5,
+          "rushHour": false
+        }
+      },
+      "reverse": false
+    },
+    {
+      "h3Address": "address1",
+      "tm": {
+        "car": {
+          "walkSpeed": 5,
+          "rushHour": false
+        }
+      },
+      "reverse": false
+    }
+  ],
+  "pathSerializer": "compact",
+  "elevation": true,
+  "reverse": false,
+  "edgeWeight": "time",
+  "serviceUrl": "",
+  "serviceKey": "",
+  "osmTypes": [],
+  "onlyPrintReachablePoints": true,
+  "forceRecalculate": false,
+  "cacheResult": true,
+  "maxEdgeWeight": 1800
+}

--- a/src/test/resources/data/RequestWithH3Addresses.json
+++ b/src/test/resources/data/RequestWithH3Addresses.json
@@ -33,6 +33,10 @@
       "reverse": false
     }
   ],
+  "targetAddresses": [
+    "address3",
+    "address4"
+  ],
   "pathSerializer": "compact",
   "elevation": true,
   "reverse": false,


### PR DESCRIPTION
Add options to use `sourceAddresses` and `targetAddresses` which allow the use of H3 addresses for sources and targets.

`sourceAddresses` is an array of objects that each have an H3 address and Travel Mode. e.g. :

```json
{
    "sourceAddresses": [
        {
            "h3Address": "address2",
            "travelType": "walk"
        },
        {
            "h3Address": "address2",
            "travelType": "car"
        }
    ]
}
```

`targetAddresses` is an array of H3 Addresses as strings e.g. :

```json
{
    "targetAddresses": [
        "address3",
        "address4"
    ]
}