### PR TITLE
Multigraph Domain Type None

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ nexus and to the maven repo (last is only possibly from master).
 ### 0.44.0
 * Support `virtualMaxEdgeWeight` in statistics criteria
 * Add response code to the error message when parsing polygon response
+* Add new multigraph domain type, `NONE`
 
 ### 0.43.0
 * Update pipeline to auto deploy to nexus on master

--- a/src/main/java/com/targomo/client/Constants.java
+++ b/src/main/java/com/targomo/client/Constants.java
@@ -101,6 +101,7 @@ public class Constants {
     public static final String MULTIGRAPH_DOMAIN_CLIP_GEOMETRY                          = "clipGeometry";
     public static final String KEY_MULTIGRAPH_DOMAIN_TYPE_EDGE                          = "edge";
     public static final String KEY_MULTIGRAPH_DOMAIN_TYPE_NODE                          = "node";
+    public static final String KEY_MULTIGRAPH_DOMAIN_TYPE_NONE                          = "none";
     public static final String KEY_MULTIGRAPH_DOMAIN_TYPE_STATISTIC_GEOMETRY            = "statistic_geometry";
     public static final String MULTIGRAPH_DOMAIN_EDGE_AGGREGATION_TYPE                  = "edgeAggregationType";
     public static final String KEY_MULTIGRAPH_DOMAIN_EDGE_AGGREGATION_TYPE_MINIMUM      = "min";

--- a/src/main/java/com/targomo/client/api/enums/MultiGraphDomainType.java
+++ b/src/main/java/com/targomo/client/api/enums/MultiGraphDomainType.java
@@ -14,6 +14,7 @@ public enum MultiGraphDomainType {
 
     NODE                (Constants.KEY_MULTIGRAPH_DOMAIN_TYPE_NODE, false),
     EDGE                (Constants.KEY_MULTIGRAPH_DOMAIN_TYPE_EDGE, false),
+    NONE                (Constants.KEY_MULTIGRAPH_DOMAIN_TYPE_NONE, false),
     STATISTIC_GEOMETRY  (Constants.KEY_MULTIGRAPH_DOMAIN_TYPE_STATISTIC_GEOMETRY, true);
 
     private final String key;

--- a/src/main/java/com/targomo/client/api/enums/MultiGraphLayerType.java
+++ b/src/main/java/com/targomo/client/api/enums/MultiGraphLayerType.java
@@ -16,11 +16,11 @@ import static com.targomo.client.api.enums.MultiGraphDomainType.*;
  */
 public enum MultiGraphLayerType {
 
-    IDENTITY            (Constants.KEY_MULTIGRAPH_LAYER_TYPE_IDENTITY,          false, MultiGraphDomainType.values()),
+    IDENTITY            (Constants.KEY_MULTIGRAPH_LAYER_TYPE_IDENTITY,          false, EDGE, NODE, STATISTIC_GEOMETRY),
     TILE                (Constants.KEY_MULTIGRAPH_LAYER_TYPE_TILE,              true,  EDGE, NODE),
     HEXAGON             (Constants.KEY_MULTIGRAPH_LAYER_TYPE_HEXAGON,           true,  EDGE, NODE),
-    H3HEXAGON           (Constants.KEY_MULTIGRAPH_LAYER_TYPE_H3HEXAGON,         true,  MultiGraphDomainType.values()),
-    CUSTOM_GEOMETRIES   (Constants.KEY_MULTIGRAPH_LAYER_TYPE_CUSTOM_GEOMETRIES, false, MultiGraphDomainType.values());
+    H3HEXAGON           (Constants.KEY_MULTIGRAPH_LAYER_TYPE_H3HEXAGON,         true,  EDGE, NODE, STATISTIC_GEOMETRY, NONE),
+    CUSTOM_GEOMETRIES   (Constants.KEY_MULTIGRAPH_LAYER_TYPE_CUSTOM_GEOMETRIES, false, EDGE, NODE, STATISTIC_GEOMETRY);
 
     private final String key;
     private final boolean requiresFixedPrecisionOrTile;


### PR DESCRIPTION
Add new domain type `NONE` for H3 hexagons for non-network dependent graph generation